### PR TITLE
Add ".test-mojom" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
                 ],
                 "extensions": [
                     ".mojom",
-                    ".test-mojom",
+                    ".test-mojom"
                 ],
                 "configuration": "./language-configuration.json"
             }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
                     "mojom"
                 ],
                 "extensions": [
-                    ".mojom"
+                    ".mojom",
+                    ".test-mojom",
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
In crbug.com/397343888, a chromium dev requested to support formatting .test-mojom files in depot_tools and VSCode.

Adding .test-mojom in package.json so that they are classified as mojom language.